### PR TITLE
fix: import of telegram-send module from the library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "northern-lights-forecast"
-version = "4.1.2"
+version = "4.1.3"
 description = "A simple web scraping northern lights forecast that automatically send a telegram notification during substorm events"
 authors = ["Eirik Rolland Enger <eirroleng@gmail.com>"]
 license = "MIT"

--- a/src/northern_lights_forecast/__init__.py
+++ b/src/northern_lights_forecast/__init__.py
@@ -1,2 +1,2 @@
 """Northern Lights Forecast."""
-__version__ = "4.1.2"
+__version__ = "4.1.3"

--- a/src/northern_lights_forecast/nlf_telegram_bot.py
+++ b/src/northern_lights_forecast/nlf_telegram_bot.py
@@ -8,9 +8,9 @@ from typing import Any
 import click
 import requests
 import telebot
-import telegram_send
 from pid import PidFile
 from pid import PidFileError
+from telegram_send import telegram_send
 
 import northern_lights_forecast.image_analysis as ima
 import northern_lights_forecast.img as img


### PR DESCRIPTION
Fixes a bug where `get_config_path` was not found:

```python
Traceback (most recent call last):
  File "/Users/eirikenger/Library/Caches/pypoetry/virtualenvs/northern-lights-forecast-lOcLA1Uq-py3.9/bin/nlfd", line 2, in <module>
    from northern_lights_forecast.nlf_telegram_bot import main
  File "/Users/eirikenger/projects/northern-lights-forecast/src/northern_lights_forecast/nlf_telegram_bot.py", line 21, in <module>
    conf = telegram_send.get_config_path()
AttributeError: module 'telegram_send' has no attribute 'get_config_path'
```